### PR TITLE
Try to upgrade cmake on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ addons:
       - libasound2-dev
       - git
 script:
+  - cat /etc/apt/sources.list.d/cmake.list
+  - sudo rm /etc/apt/sources.list.d/cmake.list
   - sudo add-apt-repository --yes ppa:george-edison55/cmake-3.x
   - sudo apt-get update -q
   - sudo apt-get -y install cmake

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,21 +13,18 @@ addons:
     packages:
       - build-essential
       - make
-      - cmake
       - g++-4.9
       - libx11-dev
       - libxrandr-dev
       - libasound2-dev
       - git
-script: |
-
-  sudo add-apt-repository --yes ppa:george-edison55/cmake-3.x
-  sudo apt-get update -q
-  sudo apt-get -y install cmake
-
-  git clone https://github.com/Urho3D/Urho3D
-  cd Urho3D
-  cmake . -Wno-dev -DURHO3D_SAMPLES=0 -DURHO3D_URHO2D=0 -DURHO3D_TOOLS=0 -DURHO3D_ANGELSCRIPT=0 -DURHO3D_LUA=0 && make
-  cd ..
-  qmake heXon.pro -Wnone
-  make
+script:
+  - sudo add-apt-repository --yes ppa:george-edison55/cmake-3.x
+  - sudo apt-get update -q
+  - sudo apt-get -y install cmake
+  - git clone https://github.com/Urho3D/Urho3D
+  - cd Urho3D
+  - cmake . -Wno-dev -DURHO3D_SAMPLES=0 -DURHO3D_URHO2D=0 -DURHO3D_TOOLS=0 -DURHO3D_ANGELSCRIPT=0 -DURHO3D_LUA=0 && make
+  - cd ..
+  - qmake heXon.pro -Wnone
+  - make


### PR DESCRIPTION
The latest error is:
```
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list.d/cmake.list:1 and /etc/apt/sources.list.d/george-edison55-cmake-3_x-trusty.list:1
```
I do not know where this other `cmake.list` file comes from, but maybe it helps to remove `cmake` from the list of packages

I've also reformatted the `script` part to make the build log less confusing (it printed all commands as one multi-line string, rather than printing each command right before its output).